### PR TITLE
RaisimGymTorch: Make picklable, expose reward information to Python

### DIFF
--- a/raisimGymTorch/raisimGymTorch/env/RaisimGymEnv.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/RaisimGymEnv.hpp
@@ -69,6 +69,7 @@ class RaisimGymEnv {
   void turnOnVisualization() { server_->wakeup(); }
   void startRecordingVideo(const std::string& videoName ) { server_->startRecordingVideo(videoName); }
   void stopRecordingVideo() { server_->stopRecordingVideo(); }
+  raisim::Reward& getRewards() { return rewards_; }
 
  protected:
   std::unique_ptr<raisim::World> world_;
@@ -78,6 +79,7 @@ class RaisimGymEnv {
   Yaml::Node cfg_;
   int obDim_=0, actionDim_=0;
   std::unique_ptr<raisim::RaisimServer> server_;
+  raisim::Reward rewards_;
 };
 
 }

--- a/raisimGymTorch/raisimGymTorch/env/RaisimGymEnv.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/RaisimGymEnv.hpp
@@ -28,13 +28,6 @@ using EigenRowMajorMat=Eigen::Matrix<Dtype, -1, -1, Eigen::RowMajor>;
 using EigenVec=Eigen::Matrix<Dtype, -1, 1>;
 using EigenBoolVec=Eigen::Matrix<bool, -1, 1>;
 
-struct Space
-{
-  Space() {}
-  Space(const std::tuple<int, int>& shape_in) : shape(shape_in) {}
-  std::tuple<int, int> shape;
-};
-
 class RaisimGymEnv {
 
  public:

--- a/raisimGymTorch/raisimGymTorch/env/RaisimGymEnv.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/RaisimGymEnv.hpp
@@ -28,6 +28,13 @@ using EigenRowMajorMat=Eigen::Matrix<Dtype, -1, -1, Eigen::RowMajor>;
 using EigenVec=Eigen::Matrix<Dtype, -1, 1>;
 using EigenBoolVec=Eigen::Matrix<bool, -1, 1>;
 
+struct Space
+{
+  Space() {}
+  Space(const std::tuple<int, int>& shape_in) : shape(shape_in) {}
+  std::tuple<int, int> shape;
+};
+
 class RaisimGymEnv {
 
  public:

--- a/raisimGymTorch/raisimGymTorch/env/Reward.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/Reward.hpp
@@ -78,18 +78,18 @@ class Reward {
 
   const std::map<std::string, float>& getStdMapOfRewardReward() {
     for(auto& rw: rewards_)
-      reward_map_[rw.first] = rw.second.reward;
-    reward_map_["reward_sum"] = sum();
+      rewardMap_[rw.first] = rw.second.reward;
+    rewardMap_["reward_sum"] = sum();
 
-    return reward_map_;
+    return rewardMap_;
   }
 
  private:
   std::map<std::string, raisim::RewardElement> rewards_;
   std::map<std::string, float> costSum_;
-  std::map<std::string, float> reward_map_;
+  std::map<std::string, float> rewardMap_;
 };
 
-}
+}  // namespace raisim
 
 #endif //_RAISIM_GYM_TORCH_RAISIMGYMTORCH_ENV_REWARD_HPP_

--- a/raisimGymTorch/raisimGymTorch/env/Reward.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/Reward.hpp
@@ -76,7 +76,7 @@ class Reward {
     return costSum_;
   }
 
-  const std::map<std::string, float>& getStdMapOfRewardReward() {
+  const std::map<std::string, float>& getStdMap() {
     for(auto& rw: rewards_)
       rewardMap_[rw.first] = rw.second.reward;
     rewardMap_["reward_sum"] = sum();

--- a/raisimGymTorch/raisimGymTorch/env/Reward.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/Reward.hpp
@@ -76,9 +76,18 @@ class Reward {
     return costSum_;
   }
 
+  const std::map<std::string, float>& getStdMapOfRewardReward() {
+    for(auto& rw: rewards_)
+      reward_map_[rw.first] = rw.second.reward;
+    reward_map_["reward_sum"] = sum();
+
+    return reward_map_;
+  }
+
  private:
   std::map<std::string, raisim::RewardElement> rewards_;
   std::map<std::string, float> costSum_;
+  std::map<std::string, float> reward_map_;
 };
 
 }

--- a/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
@@ -132,7 +132,7 @@ class VectorizedEnvironment {
                            Eigen::Ref<EigenVec> &reward,
                            Eigen::Ref<EigenBoolVec> &done) {
     reward[agentId] = environments_[agentId]->step(action.row(agentId));
-    reward_information_[agentId] = environments_[agentId]->getRewards().getStdMapOfRewardIntegral();
+    reward_information_[agentId] = environments_[agentId]->getRewards().getStdMapOfRewardReward();
 
     float terminalReward = 0;
     done[agentId] = environments_[agentId]->isTerminalState(terminalReward);

--- a/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
@@ -23,6 +23,7 @@ class VectorizedEnvironment {
 	raisim::World::setActivationKey(raisim::Path(resourceDir + "/activation.raisim").getString());
     if(&cfg_["render"])
       render_ = cfg_["render"].template As<bool>();
+    init();
   }
 
   ~VectorizedEnvironment() {

--- a/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
@@ -33,6 +33,13 @@ class VectorizedEnvironment {
   const std::string& get_resource_directory() const { return resourceDir_; }
   const std::string& get_cfg_string() const { return cfg_string_; }
 
+  // Space action_space;
+  // Space observation_space;
+  Eigen::VectorXd action_space;
+  Eigen::VectorXd observation_space;
+  std::map<std::string, std::vector<std::string>> metadata;
+  std::tuple<double, double> reward_range;
+
   void init() {
     omp_set_num_threads(cfg_["num_threads"].template As<int>());
     num_envs_ = cfg_["num_envs"].template As<int>();
@@ -54,6 +61,12 @@ class VectorizedEnvironment {
     obDim_ = environments_[0]->getObDim();
     actionDim_ = environments_[0]->getActionDim();
     RSFATAL_IF(obDim_ == 0 || actionDim_ == 0, "Observation/Action dimension must be defined in the constructor of each environment!")
+
+    // action_space.shape = std::make_tuple<int, int>(int(actionDim_), 1);
+    // observation_space.shape = std::make_tuple<int, int>(int(obDim_), 1);
+    action_space.setZero(actionDim_);   // Work-around such that dtype is exposed proper...
+    observation_space.setZero(obDim_);  // Work-around such that dtype is exposed proper...
+    reward_range = std::make_tuple<double, double>(-std::numeric_limits<double>::infinity(), +std::numeric_limits<double>::infinity());
   }
 
   // resets all environments and returns observation

--- a/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
@@ -34,13 +34,6 @@ class VectorizedEnvironment {
   const std::string& get_resource_directory() const { return resourceDir_; }
   const std::string& get_cfg_string() const { return cfg_string_; }
 
-  // Space action_space;
-  // Space observation_space;
-  Eigen::VectorXd action_space;
-  Eigen::VectorXd observation_space;
-  std::map<std::string, std::vector<std::string>> metadata;
-  std::tuple<double, double> reward_range;
-
   void init() {
     omp_set_num_threads(cfg_["num_threads"].template As<int>());
     num_envs_ = cfg_["num_envs"].template As<int>();
@@ -65,12 +58,6 @@ class VectorizedEnvironment {
     obDim_ = environments_[0]->getObDim();
     actionDim_ = environments_[0]->getActionDim();
     RSFATAL_IF(obDim_ == 0 || actionDim_ == 0, "Observation/Action dimension must be defined in the constructor of each environment!")
-
-    // action_space.shape = std::make_tuple<int, int>(int(actionDim_), 1);
-    // observation_space.shape = std::make_tuple<int, int>(int(obDim_), 1);
-    action_space.setZero(actionDim_);   // Work-around such that dtype is exposed proper...
-    observation_space.setZero(obDim_);  // Work-around such that dtype is exposed proper...
-    reward_range = std::make_tuple<double, double>(-std::numeric_limits<double>::infinity(), +std::numeric_limits<double>::infinity());
   }
 
   // resets all environments and returns observation

--- a/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/VectorizedEnvironment.hpp
@@ -18,7 +18,7 @@ class VectorizedEnvironment {
  public:
 
   explicit VectorizedEnvironment(std::string resourceDir, std::string cfg)
-      : resourceDir_(resourceDir) {
+      : resourceDir_(resourceDir), cfg_string_(cfg) {
     Yaml::Parse(cfg_, cfg);
 	raisim::World::setActivationKey(raisim::Path(resourceDir + "/activation.raisim").getString());
     if(&cfg_["render"])
@@ -29,6 +29,9 @@ class VectorizedEnvironment {
     for (auto *ptr: environments_)
       delete ptr;
   }
+
+  const std::string& get_resource_directory() const { return resourceDir_; }
+  const std::string& get_cfg_string() const { return cfg_string_; }
 
   void init() {
     omp_set_num_threads(cfg_["num_threads"].template As<int>());
@@ -140,6 +143,7 @@ class VectorizedEnvironment {
   bool recordVideo_=false, render_=false;
   std::string resourceDir_;
   Yaml::Node cfg_;
+  std::string cfg_string_;
 };
 
 }

--- a/raisimGymTorch/raisimGymTorch/env/envs/rsg_anymal/Environment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/envs/rsg_anymal/Environment.hpp
@@ -142,7 +142,6 @@ class ENVIRONMENT : public RaisimGymEnv {
   Eigen::VectorXd actionMean_, actionStd_, obDouble_;
   Eigen::Vector3d bodyLinearVel_, bodyAngularVel_;
   std::set<size_t> footIndices_;
-  raisim::Reward rewards_;
 };
 }
 

--- a/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
+++ b/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
@@ -17,11 +17,6 @@ using namespace raisim;
 #endif
 
 PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
-  py::class_<Space>(m, "Space")
-    .def(py::init<>())
-    // .def(py::init<const std::tuple<int, int>&>())
-    .def_readonly("shape", &Space::shape);
-
   py::class_<VectorizedEnvironment<ENVIRONMENT>>(m, RSG_MAKE_STR(ENVIRONMENT_NAME))
     .def(py::init<std::string, std::string>(), py::arg("resourceDir"), py::arg("cfg"))
     .def("init", &VectorizedEnvironment<ENVIRONMENT>::init)
@@ -29,16 +24,7 @@ PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
     .def("observe", &VectorizedEnvironment<ENVIRONMENT>::observe)
     .def("step", &VectorizedEnvironment<ENVIRONMENT>::step)
     .def("setSeed", &VectorizedEnvironment<ENVIRONMENT>::setSeed)
-    .def("seed", &VectorizedEnvironment<ENVIRONMENT>::setSeed)  // OpenAI Gym compatibility
-    // .def("info", [](VectorizedEnvironment<ENVIRONMENT>* instance) {
-    //   std::cout << "ObDim " << instance->getObDim() << std::endl;
-    //   std::cout << "ActionDim " << instance->getActionDim() << std::endl;
-    //   std::cout << "NumOfEnvs " << instance->getNumOfEnvs() << std::endl;
-    // })
-    .def_readonly("action_space", &VectorizedEnvironment<ENVIRONMENT>::action_space)            // OpenAI Gym compatibility
-    .def_readonly("observation_space", &VectorizedEnvironment<ENVIRONMENT>::observation_space)  // OpenAI Gym compatibility
-    .def_readonly("metadata", &VectorizedEnvironment<ENVIRONMENT>::metadata)                    // OpenAI Gym compatibility
-    .def_readonly("reward_range", &VectorizedEnvironment<ENVIRONMENT>::reward_range)            // OpenAI Gym compatibility
+    .def("rewardInfo", &VectorizedEnvironment<ENVIRONMENT>::getRewardInfo)
     .def("close", &VectorizedEnvironment<ENVIRONMENT>::close)
     .def("isTerminalState", &VectorizedEnvironment<ENVIRONMENT>::isTerminalState)
     .def("setSimulationTimeStep", &VectorizedEnvironment<ENVIRONMENT>::setSimulationTimeStep)

--- a/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
+++ b/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
@@ -40,7 +40,7 @@ PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
     .def(py::pickle(
         [](const VectorizedEnvironment<ENVIRONMENT> &p) { // __getstate__ --> Pickling to Python
             /* Return a tuple that fully encodes the state of the object */
-            return py::make_tuple(p.get_resource_directory(), p.get_cfg_string());
+            return py::make_tuple(p.getResourceDir(), p.getCfgString());
         },
         [](py::tuple t) { // __setstate__ - Pickling from Python
             if (t.size() != 2) {

--- a/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
+++ b/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
@@ -17,6 +17,11 @@ using namespace raisim;
 #endif
 
 PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
+  py::class_<Space>(m, "Space")
+    .def(py::init<>())
+    // .def(py::init<const std::tuple<int, int>&>())
+    .def_readonly("shape", &Space::shape);
+
   py::class_<VectorizedEnvironment<ENVIRONMENT>>(m, RSG_MAKE_STR(ENVIRONMENT_NAME))
     .def(py::init<std::string, std::string>())
     .def("init", &VectorizedEnvironment<ENVIRONMENT>::init)
@@ -24,6 +29,16 @@ PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
     .def("observe", &VectorizedEnvironment<ENVIRONMENT>::observe)
     .def("step", &VectorizedEnvironment<ENVIRONMENT>::step)
     .def("setSeed", &VectorizedEnvironment<ENVIRONMENT>::setSeed)
+    .def("seed", &VectorizedEnvironment<ENVIRONMENT>::setSeed)  // OpenAI Gym compatibility
+    // .def("info", [](VectorizedEnvironment<ENVIRONMENT>* instance) {
+    //   std::cout << "ObDim " << instance->getObDim() << std::endl;
+    //   std::cout << "ActionDim " << instance->getActionDim() << std::endl;
+    //   std::cout << "NumOfEnvs " << instance->getNumOfEnvs() << std::endl;
+    // })
+    .def_readonly("action_space", &VectorizedEnvironment<ENVIRONMENT>::action_space)            // OpenAI Gym compatibility
+    .def_readonly("observation_space", &VectorizedEnvironment<ENVIRONMENT>::observation_space)  // OpenAI Gym compatibility
+    .def_readonly("metadata", &VectorizedEnvironment<ENVIRONMENT>::metadata)                    // OpenAI Gym compatibility
+    .def_readonly("reward_range", &VectorizedEnvironment<ENVIRONMENT>::reward_range)            // OpenAI Gym compatibility
     .def("close", &VectorizedEnvironment<ENVIRONMENT>::close)
     .def("isTerminalState", &VectorizedEnvironment<ENVIRONMENT>::isTerminalState)
     .def("setSimulationTimeStep", &VectorizedEnvironment<ENVIRONMENT>::setSimulationTimeStep)

--- a/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
+++ b/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
@@ -35,5 +35,23 @@ PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
     .def("turnOffVisualization", &VectorizedEnvironment<ENVIRONMENT>::turnOffVisualization)
     .def("stopRecordingVideo", &VectorizedEnvironment<ENVIRONMENT>::stopRecordingVideo)
     .def("startRecordingVideo", &VectorizedEnvironment<ENVIRONMENT>::startRecordingVideo)
-    .def("curriculumUpdate", &VectorizedEnvironment<ENVIRONMENT>::curriculumUpdate);
+    .def("curriculumUpdate", &VectorizedEnvironment<ENVIRONMENT>::curriculumUpdate)
+    .def(py::pickle(
+        [](const VectorizedEnvironment<ENVIRONMENT> &p) { // __getstate__
+            /* Return a tuple that fully encodes the state of the object */
+            // std::cout << "PICKLING TO PYTHON" << std::endl;
+            return py::make_tuple(p.get_resource_directory(), p.get_cfg_string());
+        },
+        [](py::tuple t) { // __setstate__
+            // std::cout << "PICKLING FROM PYTHON" << std::endl;
+            if (t.size() != 2) {
+              throw std::runtime_error("Invalid state!");
+            }
+
+            /* Create a new C++ instance */
+            VectorizedEnvironment<ENVIRONMENT> p(t[0].cast<std::string>(), t[1].cast<std::string>());
+
+            return p;
+        }
+    ));
 }

--- a/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
+++ b/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
@@ -52,13 +52,11 @@ PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
     .def("startRecordingVideo", &VectorizedEnvironment<ENVIRONMENT>::startRecordingVideo)
     .def("curriculumUpdate", &VectorizedEnvironment<ENVIRONMENT>::curriculumUpdate)
     .def(py::pickle(
-        [](const VectorizedEnvironment<ENVIRONMENT> &p) { // __getstate__
+        [](const VectorizedEnvironment<ENVIRONMENT> &p) { // __getstate__ --> Pickling to Python
             /* Return a tuple that fully encodes the state of the object */
-            // std::cout << "PICKLING TO PYTHON" << std::endl;
             return py::make_tuple(p.get_resource_directory(), p.get_cfg_string());
         },
-        [](py::tuple t) { // __setstate__
-            // std::cout << "PICKLING FROM PYTHON" << std::endl;
+        [](py::tuple t) { // __setstate__ - Pickling from Python
             if (t.size() != 2) {
               throw std::runtime_error("Invalid state!");
             }

--- a/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
+++ b/raisimGymTorch/raisimGymTorch/env/raisim_gym.cpp
@@ -23,7 +23,7 @@ PYBIND11_MODULE(RAISIMGYM_TORCH_ENV_NAME, m) {
     .def_readonly("shape", &Space::shape);
 
   py::class_<VectorizedEnvironment<ENVIRONMENT>>(m, RSG_MAKE_STR(ENVIRONMENT_NAME))
-    .def(py::init<std::string, std::string>())
+    .def(py::init<std::string, std::string>(), py::arg("resourceDir"), py::arg("cfg"))
     .def("init", &VectorizedEnvironment<ENVIRONMENT>::init)
     .def("reset", &VectorizedEnvironment<ENVIRONMENT>::reset)
     .def("observe", &VectorizedEnvironment<ENVIRONMENT>::observe)

--- a/raisimGymTorch/setup.py
+++ b/raisimGymTorch/setup.py
@@ -45,7 +45,7 @@ class CMakeBuild(build_ext):
         if __CMAKE_PREFIX_PATH__ is not None:
             cmake_args.append('-DCMAKE_PREFIX_PATH=' + __CMAKE_PREFIX_PATH__)
 
-        cfg = 'Debug' if __DEBUG__ else 'Release'
+        cfg = 'Debug' if __DEBUG__ else 'RelWithDebInfo'
         build_args = ['--config', cfg]
 
         if platform.system() == "Windows":


### PR DESCRIPTION
Hi @jhwangbo 
We are using RaisimGymTorch as a drop-in to OpenAI Gym and made a few adjustments:

1. The environment is now picklable, where the state is described by the resource directory and the config file.
2. We also store the reward-reward as a map in addition to the reward-integral, and we expose them to Python
3. The kwargs of the constructor are now named.
4. We explicitly call `init()` in the constructor - this way the separate call to `init()` from Python can be omitted.

Looking forward to your feedback,
Wolfgang