### PR TITLE
package.xml: Fix eigen rosdep key, install package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ install(
         ${CMAKE_INSTALL_PREFIX}
 )
 
+install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}")
+
 if(RAISIM_ALL)
     set(RAISIM_EXAMPLE TRUE)
     set(RAISIM_MATLAB TRUE)

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
     <!--Package Dependencies-->
     <buildtool_depend>cmake</buildtool_depend>
     <exec_depend>catkin</exec_depend>
-    <build_depend>eigen3</build_depend>
+    <build_depend>eigen</build_depend>
     <!--Package Export-->
     <export>
         <build_type>cmake</build_type>


### PR DESCRIPTION
The `eigen3` key does not exist - `rosdep resolve eigen` shows that `eigen` is the correct key. Also added an install hook for the package.xml.