### PR TITLE
Update RaisimSbGymVecEnv.py

### DIFF
--- a/raisimGymTorch/raisimGymTorch/stable_baselines3/RaisimSbGymVecEnv.py
+++ b/raisimGymTorch/raisimGymTorch/stable_baselines3/RaisimSbGymVecEnv.py
@@ -21,7 +21,6 @@ class RaisimSbGymVecEnv(VecEnv):
         self.normalize_rew = normalize_rew
         self.clip_obs = clip_obs
         self.wrapper = impl
-        self.wrapper.init()
         self.num_obs = self.wrapper.getObDim()
         self.num_acts = self.wrapper.getActionDim()
         self.observation_space = gym.spaces.Box(-np.full(self.num_obs, np.inf), np.full(self.num_obs, np.inf), dtype=np.float32)


### PR DESCRIPTION
Remove "wrapper.init" to avoid init VectorizedEnvironment twice (similar to https://github.com/raisimTech/raisimLib/commit/fa43b76b895c71d052d2daf94b4ae91469ce30c8).