### PR TITLE
sb3 observation variable copy() fix

### DIFF
--- a/raisimGymTorch/raisimGymTorch/stable_baselines3/RaisimSbGymVecEnv.py
+++ b/raisimGymTorch/raisimGymTorch/stable_baselines3/RaisimSbGymVecEnv.py
@@ -22,8 +22,8 @@ class RaisimSbGymVecEnv(VecEnv):
         self.wrapper = impl
         self.num_obs = self.wrapper.getObDim()
         self.num_acts = self.wrapper.getActionDim()
-        self.observation_space = gym.spaces.Box(-np.full(self.num_obs, 1e6), np.full(self.num_obs, 1e6), dtype=np.float32)
-        self.action_space = gym.spaces.Box(-np.full(self.num_acts, 1e6), np.full(self.num_acts, 1e6), dtype=np.float32)
+        self.observation_space = gym.spaces.Box(-np.full(self.num_obs, 1e6, np.float32), np.full(self.num_obs, 1e6, np.float32), dtype=np.float32)
+        self.action_space = gym.spaces.Box(-np.full(self.num_acts, 1e6, np.float32), np.full(self.num_acts, 1e6, np.float32), dtype=np.float32)
         super(RaisimSbGymVecEnv, self).__init__(self.wrapper.getNumOfEnvs(), self.observation_space, self.action_space)
 
         self._observation = np.zeros([self.num_envs, self.num_obs], dtype=np.float32)
@@ -57,7 +57,7 @@ class RaisimSbGymVecEnv(VecEnv):
 
     def step_wait(self):
         self.wrapper.step(self.actions, self._reward, self._done)
-        return self.observe(self.normalize_ob), self._reward.copy(), self._done.copy(), self._info
+        return self.observe(self.normalize_ob).copy(), self._reward.copy(), self._done.copy(), self._info
 
     def env_method(self, method_name: str, *method_args, indices: VecEnvIndices = None, **method_kwargs):
         pass

--- a/raisimGymTorch/raisimGymTorch/stable_baselines3/anymal.py
+++ b/raisimGymTorch/raisimGymTorch/stable_baselines3/anymal.py
@@ -4,7 +4,6 @@ import os
 from ruamel.yaml import YAML, dump, RoundTripDumper
 from stable_baselines3 import PPO
 from stable_baselines3.ppo import MlpPolicy
-from stable_baselines3.common.vec_env import VecNormalize
 from raisimGymTorch.env.bin import rsg_anymal
 from raisimGymTorch.stable_baselines3.RaisimSbGymVecEnv import RaisimSbGymVecEnv as VecEnv
 
@@ -19,8 +18,7 @@ task_path = stb_path + "/../env/envs/rsg_anymal"
 cfg = YAML().load(open(task_path + "/cfg.yaml", 'r'))
 
 # create environment from the configuration file
-vec_env = VecEnv(rsg_anymal.RaisimGymEnv(rsc_path, dump(cfg['environment'], Dumper=RoundTripDumper)), normalize_ob=False)
-env = VecNormalize(venv=vec_env, training=True, norm_obs=True, norm_reward=False)
+env = VecEnv(rsg_anymal.RaisimGymEnv(rsc_path, dump(cfg['environment'], Dumper=RoundTripDumper)), normalize_ob=True)
 obs = env.reset()
 
 n_steps = int(cfg['environment']['max_time'] / cfg['environment']['control_dt'])


### PR DESCRIPTION
copy() is appended to self.observe(self.normalize_ob) in RaisimSbGymVecEnv.py

Now, SB3 PPO works without VecNormalize. I have removed SB3 VecNormalize in anymal.py to change it back to the original setting. 