### PR TITLE
Install .cmake to correct location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,20 @@ file(GLOB_RECURSE RAISIM_LIBS "${CMAKE_CURRENT_LIST_DIR}/raisim/${RAISIM_BIN_DIR
 set(RAISIM_PY_LIBS ${RAISIM_LIBS})
 list(FILTER RAISIM_PY_LIBS INCLUDE REGEX "^${CMAKE_CURRENT_LIST_DIR}/raisim/${RAISIM_BIN_DIR}/lib/raisimpy")
 list(FILTER RAISIM_LIBS EXCLUDE REGEX "^${CMAKE_CURRENT_LIST_DIR}/raisim/${RAISIM_BIN_DIR}/lib/raisimpy")
+list(FILTER RAISIM_LIBS EXCLUDE REGEX "^${CMAKE_CURRENT_LIST_DIR}/raisim/${RAISIM_BIN_DIR}/lib/cmake")
 
 # Install regular libraries
 install(
         FILES
         ${RAISIM_LIBS}
+        DESTINATION
+        ${CMAKE_INSTALL_PREFIX}/lib
+)
+
+# Install cmake files
+install(
+        DIRECTORY
+        ${CMAKE_CURRENT_LIST_DIR}/raisim/${RAISIM_BIN_DIR}/lib/cmake
         DESTINATION
         ${CMAKE_INSTALL_PREFIX}/lib
 )


### PR DESCRIPTION
At present, the entire `*.cmake` files gets installed to `${CMAKE_INSTALL_PREFIX}/lib`. This results cause `find_package(raisim CONFIG REQUIRED)` can not work:

```text
CMake Error at CMakeLists.txt:4 (find_package):
  Could not find a package configuration file provided by "raisim" with any
  of the following names:

    raisimConfig.cmake
    raisim-config.cmake

  Add the installation prefix of "raisim" to CMAKE_PREFIX_PATH or set
  "raisim_DIR" to a directory containing one of the above files.  If "raisim"
  provides a separate development package or SDK, be sure it has been
  installed.
```

We need install `*.cmake` files to `${CMAKE_INSTALL_PREFIX}/lib/cmake/raisim`.