### PR TITLE
Fix raisimOgre compilation issue

### DIFF
--- a/raisim/linux/include/raisim/contact/BisectionContactSolver.hpp
+++ b/raisim/linux/include/raisim/contact/BisectionContactSolver.hpp
@@ -92,7 +92,7 @@ class BisectionContactSolver {
 
   int getLoopCounter() const { return loopCounter_; }
 
-//  const std::vector<double>& getErrorHistory() const { return error_; }
+  const std::vector<double>& getErrorHistory() const { return error_; }
 
   SolverConfiguration& getConfig() { return config_; }
   [[nodiscard]] const SolverConfiguration& getConfig() const { return config_; }


### PR DESCRIPTION
**Description**

This PR addresses a compilation issue with [raisimOgre](https://github.com/raisimTech/raisimOgre) that several people, including myself, encountered. [Link to Issue](https://github.com/raisimTech/raisimOgre/issues/32)

Upon some investigation, I found that the getErrorHistory() method was commented out. I couldn't identify a specific reason for this, so I re-enabled the method and recompiled raisimOgre. The compilation completed successfully without introducing any breaking changes.

**Summary of Changes**

    Uncommented the getErrorHistory() method to resolve the compilation error.

Impact

    Non-breaking change – This fix resolves the compilation issue while maintaining existing functionality.

Please feel free to provide feedback or request additional changes.